### PR TITLE
Fix BSM d1 formula

### DIFF
--- a/BSM_Option_Pricing.ipynb
+++ b/BSM_Option_Pricing.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "def BSM(s0, k, r , t, vol, sims, path):\n",
-    " d1= (np.log(s0/k)+(r+0.5*vol*vol)*t)/vol*np.sqrt(t)\n",
+    " d1= (np.log(s0/k)+(r+0.5*vol*vol)*t)/(vol*np.sqrt(t))\n",
     " d2= d1- vol*np.sqrt(t)\n",
     " S= np.zeros((sims, path+1)) #creating the MC array\n",
     " dt= t/path\n",
@@ -570,7 +570,7 @@
    "source": [
     "St= S.iloc[:,-1].mean(axis=0) #We take all rows from the last column of the dataframe, ST, and compute their means\n",
     "#axis = 0 means we run this computation vertical-wise (so for the column)\n",
-    "d1= (np.log(s0/k)+(r+0.5*vol*vol)*t)/vol*np.sqrt(t)\n",
+    "d1= (np.log(s0/k)+(r+0.5*vol*vol)*t)/(vol*np.sqrt(t))\n",
     "d2= d1- vol*np.sqrt(t)\n",
     "Call= np.maximum(St*norm.cdf(d1)-k*np.exp(-r*t)*norm.cdf(d2),0)\n",
     "Put = np.maximum(k * np.exp(-r * t) * norm.cdf(-d2) - St * norm.cdf(-d1), 0) #cdf to get the cumulative density function (fonction de repartition) of the normal law N()\n"


### PR DESCRIPTION
## Summary
- correct parentheses for the Black–Scholes `d1` computation in BSM_Option_Pricing notebook

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68452256385c8332950c219ecd1ef6ad