### PR TITLE
Improve volatility surface rendering

### DIFF
--- a/Vol_Smile_Surface.ipynb
+++ b/Vol_Smile_Surface.ipynb
@@ -21,7 +21,8 @@
     "import pandas as pd\n",
     "import yfinance as yf\n",
     "import datetime as dt\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.tri as mtri\n"
    ]
   },
   {
@@ -175,37 +176,34 @@
     }
    ],
    "source": [
-    "\n",
     "# Get relevant columns for plotting\n",
     "strikes = call_options_data['strike']\n",
     "days_to_maturity = call_options_data['Days to Maturity']\n",
     "implied_volatility = call_options_data['impliedVolatility']\n",
     "\n",
-    "# 3D plotting of Volatility Surface\n",
+    "# 3D plotting of Volatility Surface using triangulation\n",
     "fig = plt.figure(figsize=(12, 8))\n",
     "ax = fig.add_subplot(111, projection='3d')\n",
-    "scatter = ax.scatter(strikes, days_to_maturity, implied_volatility, c=implied_volatility, cmap='viridis')\n",
     "\n",
-    "# Set plot labels and title\n",
+    "triang = mtri.Triangulation(strikes, days_to_maturity)\n",
+    "surf = ax.plot_trisurf(triang, implied_volatility, cmap='viridis', linewidth=0.2, antialiased=True)\n",
+    "\n",
     "ax.set_xlabel('Strike Price')\n",
     "ax.set_ylabel('Days to Maturity')\n",
     "ax.set_zlabel('Implied Volatility')\n",
     "ax.set_title('Volatility Surface')\n",
     "\n",
-    "# Add implied vol color bar legend\n",
-    "cbar = fig.colorbar(scatter, ax=ax, shrink=0.5, aspect=5)\n",
+    "cbar = fig.colorbar(surf, ax=ax, shrink=0.5, aspect=5)\n",
     "cbar.set_label('Implied Volatility')\n",
-    "\n",
     "plt.show()\n",
     "\n",
-    "# 2D Scatter Plot (Implied Volatility vs Strike Price)\n",
+    "# 2D Contour Plot for additional perspective\n",
     "plt.figure(figsize=(12, 8))\n",
-    "plt.scatter(strikes, implied_volatility, c=days_to_maturity, cmap='viridis', alpha=0.7)\n",
-    "plt.colorbar(label='Days to Maturity')\n",
+    "cs = plt.tricontourf(triang, implied_volatility, levels=20, cmap='viridis')\n",
+    "plt.colorbar(cs, label='Implied Volatility')\n",
     "plt.xlabel('Strike Price')\n",
-    "plt.ylabel('Implied Volatility')\n",
-    "plt.title('2D Volatility Surface, with Maturities as colors')\n",
-    "plt.grid(True)\n",
+    "plt.ylabel('Days to Maturity')\n",
+    "plt.title('Volatility Surface Contours')\n",
     "plt.show()\n"
    ]
   }


### PR DESCRIPTION
## Summary
- import `matplotlib.tri` for surface plotting
- plot implied volatility surface using `plot_trisurf` and add 2D contour representation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846884a861483329fa51977647e535a